### PR TITLE
Add 'minDaysSelected' attribute

### DIFF
--- a/weekday_selector_formfield/README.md
+++ b/weekday_selector_formfield/README.md
@@ -16,7 +16,8 @@ WeekDaySelectorFormField()
 
 ## Custom Example
 You can set the 'displayDay' attribute to choose the days you want to show. These days will appear in the same order of the array.
-Alternatively, you can set displayDays equal to WeekDayPicker.weekendDays or WeekDayPicker.workDays to show theese days. by default, the widget will show ALL weekDays
+Alternatively, you can set displayDays equal to WeekDayPicker.weekendDays or WeekDayPicker.workDays to show theese days. By default, the widget will show ALL weekDays.
+You can also set the 'minDaysSelected' attribute to the minimum number of days that must be selected. Setting this attribute will prevent deselection of already selected days, if doing so would result in the number of selected days being less than the the value of 'minDaysSelected'.
 
 Link to repository: 
 https://github.com/andreskiu/weekday_selector_formfield/tree/master/weekday_selector_formfield
@@ -25,6 +26,7 @@ https://github.com/andreskiu/weekday_selector_formfield/tree/master/weekday_sele
 WeekDaySelectorFormField(
       displayDays: [days.monday, days.wednesday, days.friday],
       initialValue: [days.monday],
+      minDaysSelected: 1,
       borderRadius: 20,
       selectedFillColor: Colors.orange,
       borderSide: BorderSide(color: Colors.red, width: 2),

--- a/weekday_selector_formfield/lib/weekday_selector_formfield.dart
+++ b/weekday_selector_formfield/lib/weekday_selector_formfield.dart
@@ -26,6 +26,7 @@ class WeekDaySelectorFormField extends StatefulWidget {
       this.splashColor,
       this.borderSide = const BorderSide(color: Colors.black, width: 1),
       this.initialValue,
+      this.minDaysSelected,
       this.textStyle = const TextStyle(color: Colors.black),
       this.errorTextStyle = const TextStyle(color: Colors.red),
       this.axis = Axis.horizontal,
@@ -41,6 +42,7 @@ class WeekDaySelectorFormField extends StatefulWidget {
       : super(key: key);
 
   final List<days> initialValue;
+  final int minDaysSelected;
   final void Function(List<days>) onChange;
   final void Function(List<days>) onSaved;
   final String Function(List<days>) validator;
@@ -86,12 +88,16 @@ class WeekDaySelectorFormField extends StatefulWidget {
 class _WeekDaySelectorFormFieldState extends State<WeekDaySelectorFormField> {
   List<Widget> displayedDays = [];
   List<days> daysSelected = [];
+  int minDaysSelected = 0;
 
   @override
   void initState() {
     super.initState();
     if (this.widget.initialValue != null)
       daysSelected = this.widget.initialValue;
+
+    if (this.widget.minDaysSelected != null)
+      minDaysSelected = this.widget.minDaysSelected;
 
     // create all DisplayDays
     this.widget.displayDays.forEach((day) {
@@ -120,15 +126,23 @@ class _WeekDaySelectorFormFieldState extends State<WeekDaySelectorFormField> {
     });
   }
 
-  _dayTap(days day) {
+  bool _dayTap(days day) {
+    bool updated = false;
+
     if (daysSelected.contains(day)) {
-      daysSelected.remove(day);
+      if (daysSelected.length > minDaysSelected) {
+        updated = true;
+        daysSelected.remove(day);
+      }
+
     } else {
       daysSelected.add(day);
+      updated = true;
     }
     if (widget.onChange != null) {
       widget.onChange(daysSelected);
     }
+    return updated;
   }
 
   @override
@@ -220,12 +234,15 @@ class __DayItemState extends State<_DayItem> {
       constraints: this.widget.boxConstraints,
       child: RawMaterialButton(
           onPressed: () {
-            if (widget.onTap != null) {
-              widget.onTap(widget.value);
-            }
-            setState(() {
-              selected = !selected;
-            });
+              bool updated;
+              if (widget.onTap != null) {
+                updated = widget.onTap(widget.value);
+              }
+              if (updated) {
+                setState(() {
+                selected = !selected;
+                });
+              }
           },
           focusColor: widget.selectedFillColor,
           highlightColor: Colors.yellow,


### PR DESCRIPTION
Add the new attribute 'minDaysSelected'  to enable the setting of a minimum number of selected days required. The widget will then prevent a user from deselecting an already selected day if doing so would result in the number of days selected being less than the 'minDaysSelected'.